### PR TITLE
fix(ticket#119): Fixed Peer Deps Error in Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: '18'
 
       - name: Install dependencies
-        run: npm install
+        run: npm install --legacy-peer-deps
 
       - name: Build project
         run: npm run build


### PR DESCRIPTION
### Description
This pull request addresses a build error caused by peer dependency conflicts during the npm install step.To resolve this issue, I added the --legacy-peer-deps flag to the npm install command in the workflow file.