### PR TITLE
fix(ticket#289): Fix Horizontal Stretching of Login Page on Mobile Screens

### DIFF
--- a/src/app/(auth)/login/components/Login.tsx
+++ b/src/app/(auth)/login/components/Login.tsx
@@ -70,7 +70,6 @@ export const LoginPage = () => {
   } = form;
 
   return (
-    <FormWrapper>
     <div className="h-full flex items-center justify-center p-4">
     <div className="bg-white rounded-lg shadow-2xl overflow-hidden max-w-md w-full">
       <div className="flex justify-center item-center pt-8 ">
@@ -172,6 +171,5 @@ export const LoginPage = () => {
         </Form>
       </div>
     </div>
-    </FormWrapper>
   );
 };

--- a/src/app/(auth)/login/components/Login.tsx
+++ b/src/app/(auth)/login/components/Login.tsx
@@ -23,7 +23,6 @@ import { toast } from "@/hooks/use-toast";
 import { useMask } from "@react-input/mask";
 import { PHONENUMBER_VALIDATOR_REGEX } from "@/lib/regex";
 import Image from "next/image";
-import FormWrapper from "@/common/FormWrapper";
 import { loginUser } from "@/app/(auth)/login/actions/loginUser";
 
 const userSchema = z.object({

--- a/src/app/(auth)/login/layout.tsx
+++ b/src/app/(auth)/login/layout.tsx
@@ -3,5 +3,5 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  return <div className="h-screen">{children}</div>;
+  return <div className="p-4 mx-auto w-full sm:w-3/4 bg-white rounded h-screen">{children}</div>;
 }

--- a/src/common/FormWrapper.tsx
+++ b/src/common/FormWrapper.tsx
@@ -5,7 +5,7 @@ type Props = {
 };
 const FormWrapper = ({ children }: Props) => {
   return (
-    <div className="p-4 mx-auto w-3/4  sm:w-2/4 bg-white rounded h-full">
+    <div className="p-8 mx-auto w-full sm:w-3/4 bg-white rounded h-full">
       {children}
     </div>
   );


### PR DESCRIPTION
## Change Request

This PR contains the issue of extra spacing on the login page and other pages on mobile screens.

### Implementation

* `FormWrapper.tsx` handles the layout for all form pages.
* `/login/layout.tsx` contains the layout for the login page and includes responsive styling.

### Resources

<img width="1424" alt="image" src="https://github.com/user-attachments/assets/35efc6e4-7fe3-43cd-afa9-409c41ade8b1" />

<img width="1424" alt="image" src="https://github.com/user-attachments/assets/536a01ce-371d-431d-ac93-cf4ffae69bb8" />

<img width="1424" alt="image" src="https://github.com/user-attachments/assets/1c885ddc-434f-4733-8807-5c5b7e46082e" />


