### PR TITLE
fix(ticket#293): Remove the truncation effect from the header title

### DIFF
--- a/src/common/BasedBreadCrumb/BasedBreadCrumb.tsx
+++ b/src/common/BasedBreadCrumb/BasedBreadCrumb.tsx
@@ -38,7 +38,7 @@ export const BasedBreadCrumb = ({ breadcrumbs }: Props) => {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   asChild
-                  className={`max-w-20 text-sm font-medium text-gray-800 truncate  md:max-w-none ${
+                  className={`max-w-20 text-sm font-medium text-gray-800 whitespace-nowrap md:max-w-none ${
                     pathname === breadcrumb.href
                       ? "text-foreground"
                       : "transition-colors"


### PR DESCRIPTION
## Change Request

This PR removes the truncation effect from the header title, which didn't look good, and adds a "no-wrap" effect instead.

### Implementation

* `BasedBreadCrumb.tsx` contains the common breadcrumb component.

### Resources


<img width="1424" alt="image" src="https://github.com/user-attachments/assets/fa726b4a-ba03-4d81-8f89-8ecd035be8f0" />

<img width="1424" alt="image" src="https://github.com/user-attachments/assets/ec6d4680-fc44-4af5-95f6-81bb4c554c0e" />


