### PR TITLE
feat(ticket#300): Add Funds UI with Validation and Header

### DIFF
--- a/src/app/(app)/funds/actions/add-funds.ts
+++ b/src/app/(app)/funds/actions/add-funds.ts
@@ -1,0 +1,19 @@
+"use server";
+import { redirect } from "next/navigation";
+import { Routes } from "@/lib/routes";
+import { Tables } from "@/lib/db";
+import { getSupabaseClient } from "@/utils/supabase/supabaseClient";
+import { FundSchemaType } from "../components/FundFormBuilder";
+
+export const addFunds = async (values: FundSchemaType) => {
+  const supabase = await getSupabaseClient();
+  const { error } = await supabase.from(Tables.Funds).insert({
+    member_id: values.memberId,
+    amount: values.amount,
+  });
+  if (error) {
+    return error;
+  }
+
+  redirect(Routes.Fund);
+};

--- a/src/app/(app)/funds/actions/get-fund-by-id.ts
+++ b/src/app/(app)/funds/actions/get-fund-by-id.ts
@@ -1,0 +1,24 @@
+"use server";
+
+import { Tables } from "@/lib/db";
+import { getSupabaseClient } from "@/utils/supabase/supabaseClient";
+
+export const getFundDetailsById = async (fundId: number) => {
+  const supabase = await getSupabaseClient();
+  const { data : fundDetails, error } = await supabase
+    .from(Tables.Funds)
+    .select()
+    .eq("id", fundId)
+    .single();
+
+  if (error) {
+    throw error.message;
+  }
+
+  return {
+    id: fundDetails.id,
+    createdAt: fundDetails.created_at,
+    memberId: fundDetails.member_id,
+    amount: fundDetails.amount,
+  };
+};

--- a/src/app/(app)/funds/actions/update-fund-details.ts
+++ b/src/app/(app)/funds/actions/update-fund-details.ts
@@ -1,0 +1,28 @@
+"use server";
+
+import { Tables } from "@/lib/db";
+import { getSupabaseClient } from "@/utils/supabase/supabaseClient";
+import { z } from "zod";
+import { revalidatePath } from "next/cache";
+import { Routes } from "@/lib/routes";
+import { FundSchema } from "../components/FundFormBuilder";
+
+export const updateFundDetails = async (
+  fundId: number,
+  values: z.infer<typeof FundSchema>
+) => {
+  const supabase = await getSupabaseClient();
+  const { error } = await supabase
+    .from(Tables.Funds)
+    .update({
+      member_id: values.memberId,
+      amount: values.amount,
+    })
+    .eq("id", fundId);
+
+  if (error) {
+    throw error.message;
+  }
+
+  revalidatePath(Routes.Fund);
+};

--- a/src/app/(app)/funds/add/page.tsx
+++ b/src/app/(app)/funds/add/page.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { FundFormBuilder } from "../components/FundFormBuilder";
+import { Routes } from "@/lib/routes";
+import { FundHeader } from "../components/FundHeader";
+
+const Page = () => {
+  const breadcrumbs = [
+    { href: Routes.Fund, label: "Funds" },
+    { href: Routes.AddFund, label: "New Fund" },
+  ];
+  return (
+    <>
+      <FundHeader breadcrumbs={breadcrumbs} />
+      <FundFormBuilder />
+    </>
+  );
+};
+
+export default Page;

--- a/src/app/(app)/funds/components/FundFormBuilder.tsx
+++ b/src/app/(app)/funds/components/FundFormBuilder.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import React from "react";
+import FormWrapper from "@/common/FormWrapper";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { FormTitle } from "@/common/FormTitle/FormTitle";
+import { Input } from "@/components/ui/input";
+
+export const FundSchema = z.object({
+  name: z.string().min(1, {
+    message: "Name is required.",
+  }),
+  amount: z
+    .string()
+    .min(1, {
+      message: "Amount is required.",
+    })
+    .refine((value) => !isNaN(parseFloat(value)) && parseFloat(value) > 0, {
+      message: "Amount must be a valid positive number.",
+    }),
+});
+
+export type FundSchemaType = z.infer<typeof FundSchema>;
+
+export const FundFormBuilder = () => {
+  const form = useForm<FundSchemaType>({
+    resolver: zodResolver(FundSchema),
+    defaultValues: {
+      name: "",
+      amount: "",
+    },
+    mode: "all",
+  });
+
+  const { isValid } = form.formState;
+
+  function onSubmit(values: z.infer<typeof FundSchema>) {
+    return values;
+  }
+  return (
+    <FormWrapper>
+      <FormTitle title="Funds" />
+      <Form {...form}>
+        <form
+          action={() => form.handleSubmit(onSubmit)()}
+          className="space-y-4"
+        >
+          <FormField
+            control={form.control}
+            name={"name"}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Name</FormLabel>
+                <FormControl>
+                  <Input placeholder="Enter Name" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name={"amount"}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Amount</FormLabel>
+                <FormControl>
+                  <Input placeholder="Enter Amount" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <div className="flex justify-end">
+            <Button type="submit" disabled={!isValid} className="text-xs">
+              Submit
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </FormWrapper>
+  );
+};

--- a/src/app/(app)/funds/components/FundFormBuilder.tsx
+++ b/src/app/(app)/funds/components/FundFormBuilder.tsx
@@ -16,9 +16,10 @@ import {
 } from "@/components/ui/form";
 import { FormTitle } from "@/common/FormTitle/FormTitle";
 import { Input } from "@/components/ui/input";
+import { MemberSelector } from "@/common/MemberSelector/MemberSelector";
 
 export const FundSchema = z.object({
-  name: z.string().min(1, {
+  memberId: z.string().min(1, {
     message: "Name is required.",
   }),
   amount: z
@@ -37,7 +38,7 @@ export const FundFormBuilder = () => {
   const form = useForm<FundSchemaType>({
     resolver: zodResolver(FundSchema),
     defaultValues: {
-      name: "",
+      memberId: "",
       amount: "",
     },
     mode: "all",
@@ -46,6 +47,7 @@ export const FundFormBuilder = () => {
   const { isValid } = form.formState;
 
   function onSubmit(values: z.infer<typeof FundSchema>) {
+    console.log({ values })
     return values;
   }
   return (
@@ -58,12 +60,15 @@ export const FundFormBuilder = () => {
         >
           <FormField
             control={form.control}
-            name={"name"}
+            name={"memberId"}
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Name</FormLabel>
+                <FormLabel>User Name</FormLabel>
                 <FormControl>
-                  <Input placeholder="Enter Name" {...field} />
+                  <MemberSelector
+                    value={field.value}
+                    onValueChange={field.onChange}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/src/app/(app)/funds/components/FundFormBuilder.tsx
+++ b/src/app/(app)/funds/components/FundFormBuilder.tsx
@@ -54,7 +54,7 @@ export const FundFormBuilder = ({ funds }: Props) => {
 
   const { isValid } = form.formState;
 
-  const onSubmit = async(values: z.infer<typeof FundSchema>) =>{
+  const onSubmit = async(values: FundSchemaType) =>{
     try {
       if (!funds?.id) {
         addFunds(values);

--- a/src/app/(app)/funds/components/FundFormBuilder.tsx
+++ b/src/app/(app)/funds/components/FundFormBuilder.tsx
@@ -16,7 +16,11 @@ import {
 } from "@/components/ui/form";
 import { FormTitle } from "@/common/FormTitle/FormTitle";
 import { Input } from "@/components/ui/input";
+import { toast } from "@/hooks/use-toast";
 import { MemberSelector } from "@/common/MemberSelector/MemberSelector";
+import { addFunds } from "../actions/add-funds";
+import { updateFundDetails } from "../actions/update-fund-details";
+import { FundType } from "@/types";
 
 export const FundSchema = z.object({
   memberId: z.string().min(1, {
@@ -34,20 +38,45 @@ export const FundSchema = z.object({
 
 export type FundSchemaType = z.infer<typeof FundSchema>;
 
-export const FundFormBuilder = () => {
+interface Props {
+  funds?: FundType;
+}
+
+export const FundFormBuilder = ({ funds }: Props) => {
   const form = useForm<FundSchemaType>({
     resolver: zodResolver(FundSchema),
     defaultValues: {
-      memberId: "",
-      amount: "",
+      memberId: funds?.memberId ?? "",
+      amount: funds?.amount ?? "",
     },
     mode: "all",
   });
 
   const { isValid } = form.formState;
 
-  function onSubmit(values: z.infer<typeof FundSchema>) {
-    return values;
+  const onSubmit = async(values: z.infer<typeof FundSchema>) =>{
+    try {
+      if (!funds?.id) {
+        addFunds(values);
+        toast({
+          title: "Success",
+          description: "Fund added successfully",
+        });
+      } else {
+        updateFundDetails(funds?.id, values);
+        toast({
+          title: "Success",
+          description: "Fund updated successfully",
+        });
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        toast({
+          title: "Error",
+          description: error.message,
+        });
+      }
+    }
   }
   return (
     <FormWrapper>
@@ -89,7 +118,7 @@ export const FundFormBuilder = () => {
 
           <div className="flex justify-end">
             <Button type="submit" disabled={!isValid} className="text-xs">
-              Submit
+              {funds?.id ? "Update" : "Submit"}
             </Button>
           </div>
         </form>

--- a/src/app/(app)/funds/components/FundFormBuilder.tsx
+++ b/src/app/(app)/funds/components/FundFormBuilder.tsx
@@ -47,7 +47,6 @@ export const FundFormBuilder = () => {
   const { isValid } = form.formState;
 
   function onSubmit(values: z.infer<typeof FundSchema>) {
-    console.log({ values })
     return values;
   }
   return (

--- a/src/app/(app)/funds/components/FundHeader.tsx
+++ b/src/app/(app)/funds/components/FundHeader.tsx
@@ -1,0 +1,27 @@
+"use client";
+import React from "react";
+import { usePathname } from "next/navigation";
+import { Routes } from "@/lib/routes";
+import NavigationButton from "@/common/NavigationButton";
+import { Breadcrumbs } from "@/types";
+import { HeaderWrapper } from "@/common/HeaderWapper/HeaderWrapper";
+
+interface Props {
+  breadcrumbs: Breadcrumbs[];
+}
+
+export const FundHeader = ({ breadcrumbs }: Props) => {
+  const pathname = usePathname();
+  return (
+    <HeaderWrapper breadcrumbs={breadcrumbs}>
+      {pathname === Routes.Fund && (
+        <div className="flex items-center space-x-2">
+          <NavigationButton
+            path={Routes.AddFund}
+            buttonText="Add Shoes"
+          />
+        </div>
+      )}
+    </HeaderWrapper>
+  );
+};

--- a/src/app/(app)/funds/edit/[id]/page.tsx
+++ b/src/app/(app)/funds/edit/[id]/page.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Routes } from "@/lib/routes";
+import { getFundDetailsById } from "../../actions/get-fund-by-id";
+import { FundFormBuilder } from "../../components/FundFormBuilder";
+import { FundHeader } from "../../components/FundHeader";
+
+const Page = async ({ params }: { params: { id: string } }) => {
+  const id = params.id;
+  const funds = await getFundDetailsById(Number(id));
+
+  const breadcrumbs = [
+    { href: Routes.Fund, label: "Funds" },
+    { href: `${Routes.EditFund}/${id}`, label: "Edit fund" },
+  ];
+
+  return (
+    <>
+      <FundHeader breadcrumbs={breadcrumbs} />
+      <FundFormBuilder funds={funds}/>
+    </>
+  );
+};
+
+export default Page;

--- a/src/common/FormWrapper.tsx
+++ b/src/common/FormWrapper.tsx
@@ -5,7 +5,7 @@ type Props = {
 };
 const FormWrapper = ({ children }: Props) => {
   return (
-    <div className="p-8 mx-auto w-full sm:w-3/4 bg-white rounded h-full">
+    <div className="p-8 mx-auto w-full  sm:w-3/4 md:w-2/4 bg-white rounded h-full">
       {children}
     </div>
   );

--- a/src/lib/db.tsx
+++ b/src/lib/db.tsx
@@ -3,4 +3,5 @@ export enum Tables {
   Attendance = "attendance",
   Leaves = "leaves",
   MissingShoes="missing_shoes",
+  Funds="funds",
 }

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -8,6 +8,7 @@ export enum Routes {
   MarkAttendance = "/attendance/review",
   Fund = "/funds",
   AddFund = "/funds/add",
+  EditFund = "/funds/edit",
   Members = "/members",
   AddMember = "/members/add",
   EditMember = "/members/edit",

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -7,6 +7,7 @@ export enum Routes {
   EditAttendance = "/attendance/edit",
   MarkAttendance = "/attendance/review",
   Fund = "/funds",
+  AddFund = "/funds/add",
   Members = "/members",
   AddMember = "/members/add",
   EditMember = "/members/edit",

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -1,3 +1,4 @@
+import { FundSchemaType } from "@/app/(app)/funds/components/FundFormBuilder";
 import {
   AttendanceStatus,
   LeaveTypes,
@@ -119,3 +120,8 @@ export type MissingShoeReport = {
   shoesToken: string;
   description: string;
 };
+
+export interface FundType extends FundSchemaType {
+  id: number;
+  createdAt: string;
+}


### PR DESCRIPTION
## Change Request

This PR contains the Add Funds UI along with form validation. It also includes a Header with breadcrumb titles, and an Add Fund button that is displayed when the route is `/fund`.

### Implementation

* `FundFormBuilder.tsx` contains the Add Funds UI along with form validation 
* `FundHeader.tsx` contains a Header with breadcrumb titles, and an Add Fund button 
* `FormWrapper.tsx` contains form wrapper minor UI fix

### Resources

<img width="1680" alt="image" src="https://github.com/user-attachments/assets/464d9b91-2950-43d0-b734-1e3ef647ff18" />

<img width="1200" alt="image" src="https://github.com/user-attachments/assets/7ced43f3-b33c-438a-befd-ed123f9c04af" />

<img width="1200" alt="image" src="https://github.com/user-attachments/assets/36869ad9-78f6-4f40-9510-71bbef46839f" />

