### PR TITLE
feat(ticket#306): Update Fund Details Implementation

### DIFF
--- a/src/app/(app)/funds/actions/add-funds.ts
+++ b/src/app/(app)/funds/actions/add-funds.ts
@@ -7,7 +7,10 @@ import { FundSchemaType } from "../components/FundFormBuilder";
 
 export const addFunds = async (values: FundSchemaType) => {
   const supabase = await getSupabaseClient();
-  const { error } = await supabase.from(Tables.Funds).insert(values);
+  const { error } = await supabase.from(Tables.Funds).insert({
+    member_id: values.memberId,
+    amount: values.amount,
+  });
   if (error) {
     return error;
   }

--- a/src/app/(app)/funds/actions/get-fund-by-id.ts
+++ b/src/app/(app)/funds/actions/get-fund-by-id.ts
@@ -9,7 +9,7 @@ export const getFundDetailsById = async (fundId: number) => {
     .from(Tables.Funds)
     .select()
     .eq("id", fundId)
-    .maybeSingle();
+    .single();
 
   if (error) {
     throw error.message;

--- a/src/app/(app)/funds/actions/get-fund-by-id.ts
+++ b/src/app/(app)/funds/actions/get-fund-by-id.ts
@@ -5,7 +5,7 @@ import { getSupabaseClient } from "@/utils/supabase/supabaseClient";
 
 export const getFundDetailsById = async (fundId: number) => {
   const supabase = await getSupabaseClient();
-  const { data, error } = await supabase
+  const { data : fundDetails, error } = await supabase
     .from(Tables.Funds)
     .select()
     .eq("id", fundId)
@@ -16,9 +16,9 @@ export const getFundDetailsById = async (fundId: number) => {
   }
 
   return {
-    id: data.id,
-    createdAt: data.created_at,
-    memberId: data.member_id,
-    amount: data.amount,
+    id: fundDetails.id,
+    createdAt: fundDetails.created_at,
+    memberId: fundDetails.member_id,
+    amount: fundDetails.amount,
   };
 };

--- a/src/app/(app)/funds/actions/get-fund-by-id.ts
+++ b/src/app/(app)/funds/actions/get-fund-by-id.ts
@@ -15,5 +15,10 @@ export const getFundDetailsById = async (fundId: number) => {
     throw error.message;
   }
 
-  return data;
+  return {
+    id: data.id,
+    createdAt: data.created_at,
+    memberId: data.member_id,
+    amount: data.amount,
+  };
 };

--- a/src/app/(app)/funds/actions/get-fund-by-id.ts
+++ b/src/app/(app)/funds/actions/get-fund-by-id.ts
@@ -1,0 +1,19 @@
+"use server";
+
+import { Tables } from "@/lib/db";
+import { getSupabaseClient } from "@/utils/supabase/supabaseClient";
+
+export const getFundDetailsById = async (fundId: number) => {
+  const supabase = await getSupabaseClient();
+  const { data, error } = await supabase
+    .from(Tables.Funds)
+    .select()
+    .eq("id", fundId)
+    .maybeSingle();
+
+  if (error) {
+    throw error.message;
+  }
+
+  return data;
+};

--- a/src/app/(app)/funds/actions/update-fund-details.ts
+++ b/src/app/(app)/funds/actions/update-fund-details.ts
@@ -1,0 +1,25 @@
+"use server";
+
+import { Tables } from "@/lib/db";
+import { getSupabaseClient } from "@/utils/supabase/supabaseClient";
+import { z } from "zod";
+import { revalidatePath } from "next/cache";
+import { Routes } from "@/lib/routes";
+import { FundSchema } from "../components/FundFormBuilder";
+
+export const updateFundDetails = async (
+  fundId: number,
+  values: z.infer<typeof FundSchema>
+) => {
+  const supabase = await getSupabaseClient();
+  const { error } = await supabase
+    .from(Tables.Funds)
+    .update(values)
+    .eq("id", fundId);
+
+  if (error) {
+    throw error.message;
+  }
+
+  revalidatePath(Routes.Fund);
+};

--- a/src/app/(app)/funds/actions/update-fund-details.ts
+++ b/src/app/(app)/funds/actions/update-fund-details.ts
@@ -14,7 +14,10 @@ export const updateFundDetails = async (
   const supabase = await getSupabaseClient();
   const { error } = await supabase
     .from(Tables.Funds)
-    .update(values)
+    .update({
+      member_id: values.memberId,
+      amount: values.amount,
+    })
     .eq("id", fundId);
 
   if (error) {

--- a/src/app/(app)/funds/components/FundFormBuilder.tsx
+++ b/src/app/(app)/funds/components/FundFormBuilder.tsx
@@ -21,8 +21,8 @@ import { useRouter } from "next/navigation";
 import { Routes } from "@/lib/routes";
 import { MemberSelector } from "@/common/MemberSelector/MemberSelector";
 import { addFunds } from "../actions/add-funds";
-import { FundType } from "@/types";
 import { updateFundDetails } from "../actions/update-fund-details";
+import { FundType } from "@/types";
 
 export const FundSchema = z.object({
   memberId: z.string().min(1, {
@@ -77,7 +77,7 @@ export const FundFormBuilder = ({ funds }: Props) => {
       if (error instanceof Error) {
         toast({
           title: "Error",
-          description: "Something went wrong! Please try again.",
+          description: error.message,
         });
       }
     }

--- a/src/app/(app)/funds/components/FundFormBuilder.tsx
+++ b/src/app/(app)/funds/components/FundFormBuilder.tsx
@@ -17,8 +17,6 @@ import {
 import { FormTitle } from "@/common/FormTitle/FormTitle";
 import { Input } from "@/components/ui/input";
 import { toast } from "@/hooks/use-toast";
-import { useRouter } from "next/navigation";
-import { Routes } from "@/lib/routes";
 import { MemberSelector } from "@/common/MemberSelector/MemberSelector";
 import { addFunds } from "../actions/add-funds";
 import { updateFundDetails } from "../actions/update-fund-details";
@@ -45,7 +43,6 @@ interface Props {
 }
 
 export const FundFormBuilder = ({ funds }: Props) => {
-  const router = useRouter();
   const form = useForm<FundSchemaType>({
     resolver: zodResolver(FundSchema),
     defaultValues: {

--- a/src/app/(app)/funds/components/FundFormBuilder.tsx
+++ b/src/app/(app)/funds/components/FundFormBuilder.tsx
@@ -21,6 +21,8 @@ import { useRouter } from "next/navigation";
 import { Routes } from "@/lib/routes";
 import { MemberSelector } from "@/common/MemberSelector/MemberSelector";
 import { addFunds } from "../actions/add-funds";
+import { FundType } from "@/types";
+import { updateFundDetails } from "../actions/update-fund-details";
 
 export const FundSchema = z.object({
   memberId: z.string().min(1, {
@@ -38,13 +40,17 @@ export const FundSchema = z.object({
 
 export type FundSchemaType = z.infer<typeof FundSchema>;
 
-export const FundFormBuilder = () => {
+interface Props {
+  funds?: FundType;
+}
+
+export const FundFormBuilder = ({ funds }: Props) => {
   const router = useRouter();
   const form = useForm<FundSchemaType>({
     resolver: zodResolver(FundSchema),
     defaultValues: {
-      memberId: "",
-      amount: "",
+      memberId: funds?.memberId ?? "",
+      amount: funds?.amount ?? "",
     },
     mode: "all",
   });
@@ -53,11 +59,19 @@ export const FundFormBuilder = () => {
 
   function onSubmit(values: z.infer<typeof FundSchema>) {
     try {
-      addFunds(values);
-      toast({
-        title: "Success",
-        description: "Fund added successfully",
-      });
+      if (!funds?.id) {
+        addFunds(values);
+        toast({
+          title: "Success",
+          description: "Fund added successfully",
+        });
+      } else {
+        updateFundDetails(funds?.id, values);
+        toast({
+          title: "Success",
+          description: "Fund updated successfully",
+        });
+      }
       router.push(Routes.Fund);
     } catch (error) {
       if (error instanceof Error) {
@@ -108,7 +122,7 @@ export const FundFormBuilder = () => {
 
           <div className="flex justify-end">
             <Button type="submit" disabled={!isValid} className="text-xs">
-              Submit
+              {funds?.id ? "Update" : "Submit"}
             </Button>
           </div>
         </form>

--- a/src/app/(app)/funds/edit/[id]/page.tsx
+++ b/src/app/(app)/funds/edit/[id]/page.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Routes } from "@/lib/routes";
+import { getFundDetailsById } from "../../actions/get-fund-by-id";
+import { FundFormBuilder } from "../../components/FundFormBuilder";
+import { FundHeader } from "../../components/FundHeader";
+
+const Page = async ({ params }: { params: { id: string } }) => {
+  const id = params.id;
+  const funds = await getFundDetailsById(Number(id));
+
+  const breadcrumbs = [
+    { href: Routes.Fund, label: "Funds" },
+    { href: `${Routes.EditFund}/${id}`, label: "Edit fund" },
+  ];
+
+  return (
+    <>
+      <FundHeader breadcrumbs={breadcrumbs} />
+      <FundFormBuilder funds={funds}/>
+    </>
+  );
+};
+
+export default Page;

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -8,6 +8,7 @@ export enum Routes {
   MarkAttendance = "/attendance/review",
   Fund = "/funds",
   AddFund = "/funds/add",
+  EditFund = "/funds/edit",
   Members = "/members",
   AddMember = "/members/add",
   EditMember = "/members/edit",

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -119,3 +119,10 @@ export type MissingShoeReport = {
   shoesToken: string;
   description: string;
 };
+
+export type FundType = {
+  id: number;
+  created_at: string;
+  memberId: string;
+  amount: string;
+};

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -122,7 +122,7 @@ export type MissingShoeReport = {
 
 export type FundType = {
   id: number;
-  created_at: string;
+  createdAt: string;
   memberId: string;
   amount: string;
 };

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -1,3 +1,4 @@
+import { FundSchemaType } from "@/app/(app)/funds/components/FundFormBuilder";
 import {
   AttendanceStatus,
   LeaveTypes,
@@ -120,9 +121,7 @@ export type MissingShoeReport = {
   description: string;
 };
 
-export type FundType = {
+export interface FundType extends FundSchemaType {
   id: number;
   createdAt: string;
-  memberId: string;
-  amount: string;
-};
+}


### PR DESCRIPTION
## Change Request

This PR introduces functionality for adding and updating fund details, including update to the member's name and fund amount. If the logged-in user has the role of `Shift Incharge,` they can update funds related to their own shift members. If the user has the role of `Incharge,` they can update the funds for all members.

### Implementation

- `add-funds.ts` : Server action to add fund details 
- `get-fund-by-id.ts`: server action to retrieves fund details by ID.
- `update-fund-details.ts`: server action to manages the update of fund details.

### Resources

https://www.loom.com/share/35a96fa131b742a4935e42e9ed608249?sid=eb05c6dd-1f45-48b4-b705-2ddf96ede73d

https://www.loom.com/share/70e30f53da694d2b919c8d6edca07653?sid=2cb7a125-86b1-4df9-856d-82f87cfa0f00

