### PR TITLE
fix(ticket#384)resolve live crashing issue

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -41,4 +41,4 @@ export default async function updateSession(request: NextRequest) {
   });
 }
 
-export const config = { matcher: ["/"] };
+export const config = { matcher: "/((?!.*\\.).*)" };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -40,5 +40,11 @@ export default async function updateSession(request: NextRequest) {
     },
   });
 }
-
+// The matcher pattern determines which routes the middleware should apply to.
+// Pattern explanation:
+// - "/((?!.*\\.).*)" ensures the middleware applies to all routes 
+// - This excludes requests for static files like CSS, or images (e.g., "/styles.css" or "/logo.png").
+// - Examples of routes where the middleware will NOT apply:
+//   - "/styles/main.css"
+//   - "/images/logo.png"
 export const config = { matcher: "/((?!.*\\.).*)" };


### PR DESCRIPTION
### Details
This PR addresses a bug that occurred in production. The issue happened because users were able to access pages without authentication due to an incorrect matcher that was not validating invalid tokens. These pages used a hook called getLoggedInUser.ts, and when a page was accessed, the hook returned undefined, causing the required conditions to fail and the code to crash. I have now updated the matcher to properly validate users.