### PR TITLE
Fixed: Middleware Matcher

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -72,15 +72,8 @@ export default async function middleware(request: NextRequest) {
     },
   });
 }
+
+// Apply middleware to all routes except `/login`
 export const config = {
-  matcher: [
-    /*
-     * Match all request paths except for the ones starting with:
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
-     * Feel free to modify this pattern to include more paths.
-     */
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
-  ],
+  matcher: "/((?!login).*)",
 };


### PR DESCRIPTION
### Description 
This PR fixes a crash caused by accessing the logged-in user from cookies on the login page. Since the user is not expected to exist on /login, the middleware was incorrectly running on this route, leading to an undefined state.
To resolve this, I updated the matcher to exclude /login from the middleware. Now, the middleware applies to all other routes, ensuring that loggedInUser is only accessed when available, preventing crashes.